### PR TITLE
Add missing import

### DIFF
--- a/examples/visualize.py
+++ b/examples/visualize.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from typing import List, Text
+from typing import List, Text, Tuple
 
 
 def line2matrix(line: Text, n: int, m: int) -> Tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
The visualization example script throws the error: `NameError: name 'Tuple' is not defined`.
This PR fixes the error.